### PR TITLE
fix(ddescribe-iit): handle SingleEscapeCharacter

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,8 @@ function ddescribeIit(opt) {
         // HexEscapeSequence :: x HexDigit HexDigit
         var hex = '\\\\x' + x.slice(2);
         var octal = '\\\\' + o;
-        s += '(?:' + c + '|(?:\\\\' + c + ')|(?:' + unicode1 + ')|(?:' + unicode2 + ')|(?:' + hex + ')|(?:' + octal + '))';
+        var ec = /['"\\nfnrtv]/.test(c) ? '' : ('|(?:\\\\' + c + ')');
+        s += '(?:' + c + ec + '|(?:' + unicode1 + ')|(?:' + unicode2 + ')|(?:' + hex + ')|(?:' + octal + '))';
       }
       return s;
     }
@@ -252,6 +253,7 @@ function ddescribeIit(opt) {
       var renderColumn = max(0, (renderIndex - renderLineStart));
 
       var word = match[2].replace(/\t/g, tabString);
+      console.log(match[2]);
       errors.push({
         file: toRelativePath(basePath, file.path),
         str: simplifyString(match[2]),
@@ -286,6 +288,7 @@ function ddescribeIit(opt) {
               replace(/(\\x([0-9a-fA-F]{2}))/g, replaceHex).
               replace(/(\\([0-7]{1,3}))/g, replaceOctal).
               replace(/(\\(.))/g, function($0, $1, $2) {
+                // SingleCharacterEscape is not found in any matches that matter
                 return $2;
               });
 

--- a/test/ddescribe-iit.spec.js
+++ b/test/ddescribe-iit.spec.js
@@ -579,7 +579,8 @@ describe('gulp-ddescribe-iit', function() {
         "it['\\157nly']();",
         "ddescrib\\u{65} ();",
         "describe[\"\\x6Fnl\\u{79}\"]();",
-        "it['\\o\\n\\l\\y']();"
+        "it['\\o\\n\\l\\y']();",
+        "it['\\on\\l\\y']();"
         ].join('\n'))
     });
     stream = ddescribeIit({ noColor: true });
@@ -615,10 +616,10 @@ describe('gulp-ddescribe-iit', function() {
         " 5| it['\\o\\n\\l\\y']();",
         "",
         "",
-        "Found `it['only']` in mock-file.js:5:1",
-        " 4| describe[\"\\x6Fnl\\u{79}\"]();",
+        "Found `it['only']` in mock-file.js:6:1",
         " 5| it['\\o\\n\\l\\y']();",
-        "  | ^^^^^^^^^^^^^^",
+        " 6| it['\\on\\l\\y']();",
+        "  | ^^^^^^^^^^^^^",
         ""
       ].join('\n'));
     }));


### PR DESCRIPTION
Previously, only NonEscapeCharacter portion of CharacterEscapeSequence
was handled. Now, each one is handled.

Closes #5
